### PR TITLE
Path separator bug in CompileFolder on Windows

### DIFF
--- a/sass.go
+++ b/sass.go
@@ -110,7 +110,7 @@ func (c *Compiler) CompileFolder(srcPath, outPath string) error {
 		}
 
 		dir := filepath.Dir(p)
-		outDir := strings.Replace(dir, srcPath, outPath, 1)
+		outDir := strings.Replace(filepath.ToSlash(dir), filepath.ToSlash(srcPath), filepath.ToSlash(outPath), 1)
 		if err := os.MkdirAll(outDir, 0770); err != nil {
 			return err
 		}


### PR DESCRIPTION
Hi,

The string replace logic in `CompileFolder` wasn't working so well when I was passing `/` as a separator on Windows  systems (half the strings would used `\` and half `/`) so this will normalise the separators.
